### PR TITLE
Fix mktemp calls

### DIFF
--- a/run-queries.sh
+++ b/run-queries.sh
@@ -32,11 +32,11 @@ query=$(tr ' ' '+' < "${query_file}")
 
 ## for storing the results before sorting and uniqing them
 rm -f /tmp/github-query-results.txt
-tempfile=$(mktemp /tmp/github-query-results.txt)
+tempfile=$(mktemp /tmp/github-query-results-XXX.txt)
 #trap "rm -f ${tempfile}" 0 2 3 15
 
 rm -f /tmp/github-hash-results.txt
-hashfile=$(mktemp /tmp/github-hash-results.txt)
+hashfile=$(mktemp /tmp/github-hash-results-XXX.txt)
 #trap "rm -f ${hashfile}" 0 2 3 15
 
 # find the repos


### PR DESCRIPTION
According to the [man pages](https://linux.die.net/man/1/mktemp) on my system, the `mktemp` command requires three "X" characters to create a unique string.