### PR TITLE
Fix query script

### DIFF
--- a/run-queries.sh
+++ b/run-queries.sh
@@ -59,7 +59,9 @@ for i in $(seq "${page_count}"); do
             -o "${curl_output_file}" \
             "${full_query}")
 
-        # 200 and 422 are both non-error codes.
+        # 200 and 422 are both non-error codes. Failures are usually due to
+        # triggering the abuse detection mechanism for sending too many
+        # requests, so we add a delay when this happens.
         if [ "${status_code}" -eq 200 ] || [ "${status_code}" -eq 422 ]; then
             break
         elif [ "${tries}" -lt $((query_tries - 1)) ]; then
@@ -68,7 +70,7 @@ for i in $(seq "${page_count}"); do
     done
 
     # GitHub only returns the first 1000 results. Requests pass this limit
-    # return 422.
+    # return 422 so stop making requests in this case.
     if [ "${status_code}" -eq 422 ]; then
         break;
     elif [ "${status_code}" -ne 200 ]; then

--- a/run-queries.sh
+++ b/run-queries.sh
@@ -74,7 +74,7 @@ for i in $(seq "${page_count}"); do
     elif [ "${status_code}" -ne 200 ]; then
         echo "GitHub query failed, last response:"
         cat "${curl_output_file}"
-        rm -rf "${curl_output_file}"
+        rm -f "${curl_output_file}"
         exit 1
     fi
     # this removes projects that are
@@ -95,7 +95,7 @@ for i in $(seq "${page_count}"); do
     | grep -v "AndroidSDKSources" >> "${tempfile}"
 done
 
-rm -rf "${curl_output_file}"
+rm -f "${curl_output_file}"
 
 sort -u -o "${tempfile}" "${tempfile}"
 

--- a/run-queries.sh
+++ b/run-queries.sh
@@ -51,7 +51,6 @@ for i in $(seq "${page_count}"); do
     fi
 
     full_query='https://api.github.com/search/code?q='${query}'&page='${i}
-    curl_output_file=$(mktemp "curl-output-XXX.txt")
     for tries in $(seq ${query_tries}); do
         status_code=$(curl -s \
             -H "Authorization: token $(cat git-personal-access-token)" \
@@ -75,6 +74,7 @@ for i in $(seq "${page_count}"); do
     elif [ "${status_code}" -ne 200 ]; then
         echo "GitHub query failed, last response:"
         cat "${curl_output_file}"
+        rm -rf "${curl_output_file}"
         exit 1
     fi
     # this removes projects that are
@@ -94,6 +94,8 @@ for i in $(seq "${page_count}"); do
     | grep -v "apache-harmony" \
     | grep -v "AndroidSDKSources" >> "${tempfile}"
 done
+
+rm -rf "${curl_output_file}"
 
 sort -u -o "${tempfile}" "${tempfile}"
 

--- a/run-queries.sh
+++ b/run-queries.sh
@@ -41,6 +41,8 @@ rm -f /tmp/github-hash-results.txt
 hashfile=$(mktemp /tmp/github-hash-results.txt)
 #trap "rm -f ${hashfile}" 0 2 3 15
 
+curl_output_file=$(mktemp curl-output-XXX.txt --tmpdir)
+
 # find the repos
 for i in $(seq "${page_count}"); do
     # GitHub only allows 30 searches per minute, so add a delay to each request.


### PR DESCRIPTION
This addresses several issues with the query script.

1. When specifying multiple headers with `curl`, the `-H` option is required for each one. When I remove the `-s` option, `curl` prints out errors because of this.
2. According to [GitHub search documentation](https://developer.github.com/v3/search/), only 30 search requests per minute are allowed. I first tried adding a two second delay to each query, but for some reason it was still giving an error. I tried gradually increasing this until I got to 10 seconds but no matter what, it eventually failed. What I ended up doing was a 5 second delay, and when it fails a 20 second delay and then a retry.
3. After running the script and examining the curl output, it gives a message that it doesn't show more than 1000 results. This happens around the 34th page or so. In this case the http code 422 is returned. I added a check for this to stop searching.

As a side note, none of these errors were noticeable by running the script, it more or less worked but was just outputting fewer results than it should have. If this script was previously used to generate lists with more than a couple pages, those lists are probably shorter than they should be.