### PR TITLE
Correctly remove old temporary files

### DIFF
--- a/run-queries.sh
+++ b/run-queries.sh
@@ -31,11 +31,11 @@ fi
 query=$(tr ' ' '+' < "${query_file}")
 
 ## for storing the results before sorting and uniqing them
-rm -f /tmp/github-query-results.txt
+rm -f /tmp/github-query-results-*.txt
 tempfile=$(mktemp /tmp/github-query-results-XXX.txt)
 #trap "rm -f ${tempfile}" 0 2 3 15
 
-rm -f /tmp/github-hash-results.txt
+rm -f /tmp/github-hash-results-*.txt
 hashfile=$(mktemp /tmp/github-hash-results-XXX.txt)
 #trap "rm -f ${hashfile}" 0 2 3 15
 


### PR DESCRIPTION
The temp files created by `run-dljc` are not being correctly deleted (because I didn't update the command with my last pull request, apologies). Added shell glob to correctly delete them.