### PR TITLE
Clean old DLJC output

### DIFF
--- a/configure-and-exec-dljc.sh
+++ b/configure-and-exec-dljc.sh
@@ -125,6 +125,9 @@ function configure_and_exec_dljc {
   TMP="${DLJC_CMD} $* -- ${BUILD_CMD}"
   DLJC_CMD="${TMP}"
 
+  # Remove old DLJC output.
+  rm -rf dljc-out
+
   # ensure the project is clean before invoking DLJC
   eval "${CLEAN_CMD}" < /dev/null
 


### PR DESCRIPTION
Note, opening this against `refactor-out-single-project` branch.

When running `DLJC` in the `configure_and_exec_dljc` script, it's important that the old `dljc-out` folder is removed before starting. The reason is that [here](https://github.com/kelloggm/run-dljc/blob/272f0304824a77dc9e07c5728b495aeda373ab8b/configure-and-exec-dljc.sh#L139), the existence of `dljc-out/wpi.log` is used to determine success.

This causes an issue with me for the following process:
- Run the `configure_and_exec` script on a local repository.
- Java 11 fails, runs with Java 8 and succeeds. Proceeds to run whole program inference.
- Run the script again on the same directory. However, this time since `dljc-out/wpi.log` exists, the script thinks the Java 11 build succeeded and tries to do whole program inference with Java 11 rather than Java 8. This fails and ends the script when it should have instead run with Java 8.

Alternatively, we could just remove the `dljc-out/wpi.log` file, or use a different mechanism for testing success.