### PR TITLE
Fix various correctness errors

### DIFF
--- a/summary.sh
+++ b/summary.sh
@@ -8,7 +8,7 @@ targetdir=$1
 
 total=$(find "${targetdir}" -name "*.log" | wc -l)
 
-no_build_file=$(grep -cl "no build file found for" "${targetdir}/*.log")
+no_build_file=$(grep -cl "no build file found for" "${targetdir}/"*.log)
 no_build_file_percent=$(((no_build_file*100)/total))
 
 # "old" and "new" in the below refer to the two different messages that
@@ -16,12 +16,12 @@ no_build_file_percent=$(((no_build_file*100)/total))
 # running an early set of these experiments, I realized that the original
 # message wasn't correct, and fixed it. But, for backwards compatibility,
 # this script looks for both messages and combines the counts.
-build_failed_old=$(grep -cl "dljc could not run the Checker Framework" "${targetdir}/*.log")
-build_failed_new=$(grep -cl "dljc could not run the build successfully" "${targetdir}/*.log")
+build_failed_old=$(grep -cl "dljc could not run the Checker Framework" "${targetdir}/"*.log)
+build_failed_new=$(grep -cl "dljc could not run the build successfully" "${targetdir}/"*.log)
 build_failed=$((build_failed_old+build_failed_new))
 build_failed_percent=$(((build_failed*100)/total))
 
-timed_out=$(grep -cl "dljc timed out for" "${targetdir}/*.log")
+timed_out=$(grep -cl "dljc timed out for" "${targetdir}/"*.log)
 timed_out_percent=$(((timed_out*100)/total))
 
 echo "total repositories: ${total} (100%)"
@@ -31,7 +31,7 @@ echo "timed out: ${timed_out} (~${timed_out_percent}%)"
 echo ""
 echo "timeouts:"
 echo ""
-grep -l "dljc timed out for" "${targetdir}/*.log"
+grep -l "dljc timed out for" "${targetdir}/"*.log
 echo ""
 
 for_manual_inspection=$(cat "${targetdir}/for_manual_inspection.txt")
@@ -41,6 +41,10 @@ echo ""
 echo "${for_manual_inspection}" | tr ' ' '\n'
 echo ""
 
-echo "LoC of projects to be manually inspected:"
+if [ -f "${targetdir}/loc.txt" ]; then
+    echo "LoC of projects to be manually inspected:"
 
-cat "${targetdir}/loc.txt"
+    cat "${targetdir}/loc.txt"
+else
+    echo "No LoC count found for projects to be manuall inspected"
+fi

--- a/summary.sh
+++ b/summary.sh
@@ -46,5 +46,5 @@ if [ -f "${targetdir}/loc.txt" ]; then
 
     cat "${targetdir}/loc.txt"
 else
-    echo "No LoC count found for projects to be manuall inspected"
+    echo "No LoC count found for projects to be manually inspected"
 fi

--- a/wpi-many.sh
+++ b/wpi-many.sh
@@ -153,7 +153,7 @@ do
 	# username/password if the repository no longer exists
         GIT_TERMINAL_PROMPT=0 git clone "${REPO}"
         # skip the rest of the script if cloning isn't successful
-        if [ -d "${REPO_NAME}" ]; then
+        if [ ! -d "${REPO_NAME}" ]; then
            continue
         fi
     else
@@ -196,7 +196,7 @@ done <"${INLIST}"
 
 popd || exit 5
 
-for_manual_inspection=$(grep -Zvl "no build file found for" "${OUTDIR}-results/*.log" \
+for_manual_inspection=$(grep -Zvl "no build file found for" "${OUTDIR}-results/"*.log \
     | xargs -0 grep -Zvl "dljc could not run the Checker Framework" \
     | xargs -0 grep -Zvl "dljc could not run the build successfully" \
     | xargs -0 grep -Zvl "dljc timed out for" \

--- a/wpi-many.sh
+++ b/wpi-many.sh
@@ -204,12 +204,18 @@ for_manual_inspection=$(grep -Zvl "no build file found for" "${OUTDIR}-results/"
 
 echo "${for_manual_inspection}" > "${OUTDIR}-results/for_manual_inspection.txt"
 
-# Compute lines of non-comment, non-blank Java code in the projects whose
-# results need to be inspected by hand (that is, those that WPI succeeded on).
-javafiles=$(grep -oh "\S*\.java " "${for_manual_inspection}")
+if [ -n "${for_manual_inspection}" ]; then
+    listpath=$(mktemp /tmp/cloc-file-list-XXX.txt)
+    # Compute lines of non-comment, non-blank Java code in the projects whose
+    # results need to be inspected by hand (that is, those that WPI succeeded on).
+    grep -oh "\S*\.java" "${for_manual_inspection}" | sort | uniq > "${listpath}"
 
-pushd "${SCRIPTDIR}/.." || exit 5
-wget -nc "https://github.com/AlDanial/cloc/releases/download/1.80/cloc-1.80.pl"
-popd || exit 5
+    pushd "${SCRIPTDIR}/.." || exit 5
+    wget -nc "https://github.com/AlDanial/cloc/releases/download/1.80/cloc-1.80.pl"
+    popd || exit 5
 
-perl "${SCRIPTDIR}/../cloc-1.80.pl" --report="${OUTDIR}-results/loc.txt" "${javafiles}"
+    perl "${SCRIPTDIR}/../cloc-1.80.pl" --report="${OUTDIR}-results/loc.txt" \
+        --list-file="${listpath}"
+
+    rm -f "${listpath}"
+fi


### PR DESCRIPTION
Some of the scripts aren't working for me, I've implemented the following changes.

- Fix if-check that breaks the `wpi-many.sh` script. Before it ran `wpi.sh` only
  if cloning the repository *wasn't* successful, had to invert condition.
- Remove wildcard patterns in quotes. Wildcards don't expand in quotes, at least on my machine.
- Add check for loc.txt existing reading, since this file isn't always created.
- Fix grep command for gathering files to check for lines of code. Had to remove
  space from search pattern and add filter for duplicates.
- Pass file list to cloc using a file rather than command line arguments, since
  this may contain tens of thousands of elements.
