### PR TITLE
Fix handling of trailing arguments

### DIFF
--- a/no-literal-securerandom-exact-cmd.sh
+++ b/no-literal-securerandom-exact-cmd.sh
@@ -64,6 +64,7 @@ rm -rf "${checkername}-${repolistbase}-results"
 bash wpi-many.sh -o "${checkername}-${repolistbase}" \
      -i "${PARENTDIR}/${repolist}" \
      -t ${timeout} \
+     -- \
      --checker "${checker}" \
      --quals "${qual_classpath}" \
      --lib "${checker_classpath}" \

--- a/wpi-many.sh
+++ b/wpi-many.sh
@@ -45,7 +45,9 @@
 # to DLJC without modification. See the documentation of DLJC for
 # an explanation of these arguments: https://github.com/kelloggm/do-like-javac
 # At least one such argument is required: --checker, which tells DLJC what
-# typechecker to run.
+# typechecker to run. The "--" argument should be given before the DLJC
+# arguments to indicate that the remaining arguments should be passed to DLJC
+# rather than interpreted as command line options for this script.
 #
 
 while getopts "o:i:u:t:" opt; do
@@ -178,7 +180,7 @@ do
     RESULT_LOG="${OUTDIR}-results/${REPO_NAME_HASH}-wpi.log"
     touch "${RESULT_LOG}"
 
-    "${SCRIPTDIR}/wpi.sh" -d "${REPO_FULLPATH}" -u "${GITHUB_USER}" -t "${TOUT}" "$@" &> "${RESULT_LOG}"
+    "${SCRIPTDIR}/wpi.sh" -d "${REPO_FULLPATH}" -u "${GITHUB_USER}" -t "${TOUT}" -- "$@" &> "${RESULT_LOG}"
 
     popd || exit 5
 


### PR DESCRIPTION
After parsing its arguments, the `wpi.sh` script passes any remaining arguments to DLJC. If the first such argument starts with a dash, such as in `--checker MyChecker`, then the script attempts to parse `--checker` as an option string rather than passing the argument to DLJC, at least when I run the script. The solution is to add `--` before the DLJC arguments to prevent `wpi.sh` from interpreting the arguments as options. Similarly, the `wpi-many.sh` passes any of its remaining arguments to `wpi.sh` and the same problem occurs. This means for me, when running `wpi-many.sh` I had to use two sets of `--` arguments.

This pull request fixes the `wpi-many.sh` script to manually add this `--` argument when calling into `wpi.sh` and updates the example to include the necessary `--` for calling into `wpi-many.sh`.